### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,84 @@
-# StockVSRevenue
-Descrição do Projeto:
+# código completo do projeto StockVSRevenue
 
-O projeto StockVSRevenue é uma análise abrangente que combina a exploração de dados históricos de ações e receitas das empresas Tesla e GameStop. Combinando técnicas de análise de dados, extração de informações de mercado e visualização de dados, o projeto busca entender a relação entre o desempenho de mercado e os indicadores financeiros cruciais.
+import yfinance as yf
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+import matplotlib.pyplot as plt
 
-O projeto começa extraindo meticulosamente os dados históricos de preços das ações das empresas Tesla e GameStop, bem como os dados de receita dessas empresas. Através do uso da biblioteca yfinance para os preços das ações e técnicas de web scraping para as receitas, esses dados são coletados e organizados para análise.
+# Função para criar o gráfico de ações
+def make_stock_graph(data, title):
+    plt.figure(figsize=(10, 6))
+    plt.plot(data.index, data["Close"], color='blue', label='Stock Price')
+    plt.title(title)
+    plt.xlabel("Date")
+    plt.ylabel("Stock Price (USD)")
+    plt.grid()
+    plt.legend()
+    plt.show()
 
-Ao combinar esses dados, o StockVSRevenue investiga padrões e tendências ao longo do tempo. Ele examina como flutuações nos preços das ações coincidem com mudanças nas receitas, permitindo uma compreensão mais profunda da interação entre os aspectos financeiros e o desempenho do mercado.
+# Função para criar o gráfico de receitas
+def make_revenue_graph(data, title):
+    plt.figure(figsize=(10, 6))
+    plt.bar(data["Year"], data["Revenue"], color='green', label='Revenue')
+    plt.title(title)
+    plt.xlabel("Year")
+    plt.ylabel("Revenue (USD)")
+    plt.grid()
+    plt.legend()
+    plt.show()
 
-Para fornecer insights visuais significativos, o projeto cria gráficos e painéis interativos que ilustram as variações nos preços das ações e nas receitas. Essas visualizações permitem identificar correlações, tendências sazonais e pontos de inflexão que podem influenciar as decisões de investimento e estratégias financeiras.
+# Símbolos das empresas
+tesla_ticker = "TSLA"
+gme_ticker = "GME"
 
-O painel final é a culminação desse processo de análise e visualização. Ele reúne as informações de forma clara e intuitiva, oferecendo uma visão geral das flutuações do mercado e das receitas ao longo do período analisado. O StockVSRevenue permite uma análise comparativa entre as duas empresas, Tesla e GameStop, ajudando os investidores e analistas a entender melhor como as mudanças nas receitas impactam o valor das ações.
+# Obtendo os dados de preços das ações da Tesla
+tesla = yf.Ticker(tesla_ticker)
+tesla_data = tesla.history(period="1y")
 
-Além disso, o projeto também incentiva o usuário a explorar diferentes períodos e segmentações dos dados, permitindo uma análise mais detalhada das tendências e eventos relevantes.
+# Criando o gráfico de ações da Tesla
+make_stock_graph(tesla_data, "Tesla Stock Price")
 
-Em suma, o StockVSRevenue é uma jornada analítica que transforma dados brutos em informações significativas. Seu objetivo é fornecer aos investidores, profissionais financeiros e entusiastas do mercado uma ferramenta valiosa para entender as dinâmicas complexas entre o desempenho das ações e os indicadores financeiros essenciais, permitindo assim tomadas de decisões mais informadas e estratégicas.
+# URL da página com os dados de receita da GameStop
+gme_revenue_url = "https://pt.stock-analysis-on.net/NYSE/Empresa/GameStop-Corp/Demonstracao-Financeira/Demonstracao-do-Resultado-Abrangente"
+
+# Enviando um pedido HTTP para a página
+gme_revenue_response = requests.get(gme_revenue_url)
+
+# Analisando o conteúdo HTML da página
+gme_soup = BeautifulSoup(gme_revenue_response.content, 'html.parser')
+
+# Encontrando a seção que contém os dados de receita
+revenue_section = gme_soup.find('div', class_='csTable moduletable')
+
+# Inicializando listas para armazenar anos e receitas
+years = []
+revenues = []
+
+# Percorrendo as linhas da tabela e extraindo os dados
+for row in revenue_section.find_all('tr')[1:]:
+    cols = row.find_all('td')
+    year = cols[0].get_text()
+    revenue = cols[1].get_text().replace('.', '')  # Remover pontos
+    years.append(year)
+    revenues.append(int(revenue))
+
+# Criando um DataFrame para os dados de receita da GameStop
+gme_revenue_data = pd.DataFrame({
+    "Year": years,
+    "Revenue": revenues
+})
+
+# Exibindo as últimas cinco linhas do DataFrame de receitas da GameStop
+print(gme_revenue_data.tail())
+
+# Criando o gráfico de receitas da GameStop
+make_revenue_graph(gme_revenue_data, "GameStop Revenue")
+
+# Imprimindo descrição do projeto
+project_description = """
+O projeto StockVSRevenue é uma análise abrangente que combina a exploração de dados históricos de ações e receitas das empresas Tesla e GameStop. O projeto começa extraindo meticulosamente os dados históricos de preços das ações da Tesla usando a biblioteca yfinance e os dados de receita da GameStop através de web scraping.
+Os gráficos de ações da Tesla e de receitas da GameStop são gerados usando funções de visualização personalizadas. Essas visualizações permitem uma análise comparativa entre os aspectos financeiros e o desempenho do mercado das duas empresas. O projeto visa fornecer insights sobre a interação entre o desempenho das ações e os indicadores financeiros, auxiliando investidores e analistas na tomada de decisões informadas e estratégicas.
+"""
+
+print(project_description)


### PR DESCRIPTION
# código completo do projeto StockVSRevenue
import yfinance as yf
import requests
from bs4 import BeautifulSoup
import pandas as pd
import matplotlib.pyplot as plt

# Função para criar o gráfico de ações
def make_stock_graph(data, title):
    plt.figure(figsize=(10, 6))
    plt.plot(data.index, data["Close"], color='blue', label='Stock Price')
    plt.title(title)
    plt.xlabel("Date")
    plt.ylabel("Stock Price (USD)")
    plt.grid()
    plt.legend()
    plt.show()

# Função para criar o gráfico de receitas
def make_revenue_graph(data, title):
    plt.figure(figsize=(10, 6))
    plt.bar(data["Year"], data["Revenue"], color='green', label='Revenue')
    plt.title(title)
    plt.xlabel("Year")
    plt.ylabel("Revenue (USD)")
    plt.grid()
    plt.legend()
    plt.show()

# Símbolos das empresas
tesla_ticker = "TSLA"
gme_ticker = "GME"

# Obtendo os dados de preços das ações da Tesla
tesla = yf.Ticker(tesla_ticker)
tesla_data = tesla.history(period="1y")

# Criando o gráfico de ações da Tesla
make_stock_graph(tesla_data, "Tesla Stock Price")

# URL da página com os dados de receita da GameStop
gme_revenue_url = "https://pt.stock-analysis-on.net/NYSE/Empresa/GameStop-Corp/Demonstracao-Financeira/Demonstracao-do-Resultado-Abrangente"

# Enviando um pedido HTTP para a página
gme_revenue_response = requests.get(gme_revenue_url)

# Analisando o conteúdo HTML da página
gme_soup = BeautifulSoup(gme_revenue_response.content, 'html.parser')

# Encontrando a seção que contém os dados de receita
revenue_section = gme_soup.find('div', class_='csTable moduletable')

# Inicializando listas para armazenar anos e receitas
years = []
revenues = []

# Percorrendo as linhas da tabela e extraindo os dados
for row in revenue_section.find_all('tr')[1:]:
    cols = row.find_all('td')
    year = cols[0].get_text()
    revenue = cols[1].get_text().replace('.', '')  # Remover pontos
    years.append(year)
    revenues.append(int(revenue))

# Criando um DataFrame para os dados de receita da GameStop
gme_revenue_data = pd.DataFrame({
    "Year": years,
    "Revenue": revenues
})

# Exibindo as últimas cinco linhas do DataFrame de receitas da GameStop
print(gme_revenue_data.tail())

# Criando o gráfico de receitas da GameStop
make_revenue_graph(gme_revenue_data, "GameStop Revenue")

# Imprimindo descrição do projeto
project_description = """
O projeto StockVSRevenue é uma análise abrangente que combina a exploração de dados históricos de ações e receitas das empresas Tesla e GameStop. O projeto começa extraindo meticulosamente os dados históricos de preços das ações da Tesla usando a biblioteca yfinance e os dados de receita da GameStop através de web scraping.
Os gráficos de ações da Tesla e de receitas da GameStop são gerados usando funções de visualização personalizadas. Essas visualizações permitem uma análise comparativa entre os aspectos financeiros e o desempenho do mercado das duas empresas. O projeto visa fornecer insights sobre a interação entre o desempenho das ações e os indicadores financeiros, auxiliando investidores e analistas na tomada de decisões informadas e estratégicas.
"""

print(project_description)
